### PR TITLE
This is fix for the ticket number 15 - complete order by adding paym…

### DIFF
--- a/tests/order.py
+++ b/tests/order.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -80,5 +81,31 @@ class OrderTests(APITestCase):
         self.assertEqual(len(json_response["lineitems"]), 0)
 
     # TODO: Complete order by adding payment type
+
+    def test_add_payment_type(self):
+        """
+        Complete the order by adding the payment type.
+        """
+        # Add product
+        self.test_add_product_to_order()
+
+        # Add new payment type
+        url = "/paymenttypes"
+        data = {
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2024-12-31",
+            "create_date": datetime.date.today()
+        }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+    
+        # Remove product from cart
+        url = "/orders/1"
+        data = { "payment_type": 1 }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.put(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     # TODO: New line item is not added to closed order


### PR DESCRIPTION
…ent type

Description of PR that completes issue here...

## Changes

- Added the test code in the order.py test file for completing the order by adding payment type

## Testing

Description of how to test code...

- [ ] Run test suite by running following command "python manage.py test tests.order -v1" in the terminal if the vs code is not setup to run the test


## Related Issues

- Fixes #15